### PR TITLE
Retry fetching IP config when not ready

### DIFF
--- a/rpc/open_xdatachannel.py
+++ b/rpc/open_xdatachannel.py
@@ -23,6 +23,7 @@ parser.add_argument('-a', '--apn', required=True)
 
 parser.add_argument('-n', '--nodefaultroute', action="store_true", help="Don't install modem as default route for IP traffic")
 parser.add_argument('-m', '--metric', type=int, default=1000, help="Metric for default route (higher is lower priority)")
+parser.add_argument('-t', '--ip-fetch-timeout', type=int, default=1, help="Retry interval in seconds when getting IP config")
 
 parser.add_argument('-r', '--noresolv', action="store_true", help="Don't add modem-provided DNS servers to /etc/resolv.conf")
 cfg = parser.parse_args()
@@ -61,21 +62,16 @@ if status == 0xffffffff:
         logging.error("Attach failed again, giving up")
         sys.exit(1)
 
-ip = r.execute('UtaMsCallPsGetNegIpAddrReq', rpc.pack_UtaMsCallPsGetNegIpAddrReq(), is_async=True)
-ip_values = rpc.unpack_UtaMsCallPsGetNegIpAddrReq(ip['body'])
-
-dns = r.execute('UtaMsCallPsGetNegotiatedDnsReq', rpc.pack_UtaMsCallPsGetNegotiatedDnsReq(), is_async=True)
-dns_values = rpc.unpack_UtaMsCallPsGetNegotiatedDnsReq(dns['body'])
-
-logging.info("IP address: " + ', '.join(map(str, ip_values)))
-logging.info("DNS server(s): " + ', '.join(map(str, dns_values['v4'] + dns_values['v6'])))
-
-# For some reason, on IPv6 networks, the GetNegIpAddrReq call returns 8 bytes of the IPv6 address followed by our 4 byte IPv4 address.
-# use the last nonzero IP
-for addr in ip_values[::-1]:
-    if addr.compressed != '0.0.0.0':
-        ip_addr = addr.compressed
+while True:
+    ip_addr, dns_values = rpc.get_ip(r)
+    if ip_addr is not None:
         break
+    interval = cfg.ip_fetch_timeout
+    logging.info(f"IP address couldn't be fetched, waiting {interval} seconds")
+    time.sleep(interval)
+
+logging.info("IP address: " + str(ip_addr))
+logging.info("DNS server(s): " + ', '.join(map(str, dns_values['v4'] + dns_values['v6'])))
 
 idx = ipr.link_lookup(ifname='wwan0')[0]
 


### PR DESCRIPTION
This is just a quick hack to retry fetching IP configuration from the modem when it just returns a 0.0.0.0 IP addresses / zero bytes at first try.
I don't mind if this doesn't get merged, there must be a better way to fix this. For me it fixes the error message `name 'ip_addr' is not defined` reliably.