### PR TITLE
rename 7360 to 7560

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-obj-m := xmm7360.o
+obj-m := xmm7560.o
 
 KVERSION := $(shell uname -r)
 KDIR := /lib/modules/$(KVERSION)/build
@@ -15,14 +15,14 @@ install:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
 
 load:
-	-sudo /sbin/rmmod xmm7360
-	sudo /sbin/insmod xmm7360.ko
+	-sudo /sbin/rmmod xmm7560
+	sudo /sbin/insmod xmm7560.ko
 
 unload:
-	sudo /sbin/rmmod xmm7360
+	sudo /sbin/rmmod xmm7560
 
 reset:
-	-sudo /sbin/rmmod xmm7360
+	-sudo /sbin/rmmod xmm7560
 	sudo dd if=/sys/bus/pci/devices/0000:3b:00.0/config of=/tmp/xmm_cfg bs=256 count=1 status=none
 	sudo modprobe acpi_call
 	echo '\_SB.PCI0.RP07.PXSX._RST' | sudo tee /proc/acpi/call

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # What
 
-Driver for Fibocom L850-GL / Intel XMM7360 (PCI ID 8086:7360).
+Driver for Fibocom L850-GL / Intel XMM7560 (PCI ID 8086:7560).
 
 # Status
 

--- a/rpc/mux.c
+++ b/rpc/mux.c
@@ -12,7 +12,7 @@
 #include <linux/ioctl.h>
 #include <arpa/inet.h>
 #include <time.h>
-#include "xmm7360.h"
+#include "xmm7560.h"
 
 int max_frame, max_packets_per_frame;
 
@@ -280,7 +280,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 	uint32_t val;
-	int ret = ioctl(mux, XMM7360_IOCTL_GET_PAGE_SIZE, &val);
+	int ret = ioctl(mux, XMM7560_IOCTL_GET_PAGE_SIZE, &val);
 	if (ret < 0) {
 		perror("mux ioctl");
 		exit(1);

--- a/rpc/open_xdatachannel.py
+++ b/rpc/open_xdatachannel.py
@@ -14,7 +14,7 @@ import configargparse
 
 parser = configargparse.ArgumentParser(
         description='Hacky tool to bring up XMM7x60 modem',
-        default_config_files=['./xmm7360.ini', '/etc/xmm7360'],
+        default_config_files=['./xmm7560.ini', '/etc/xmm7560'],
         )
 
 parser.add_argument('-c', '--conf', is_config_file=True)
@@ -96,7 +96,7 @@ if not cfg.nodefaultroute:
 # Add DNS values to /etc/resolv.conf
 if not cfg.noresolv:
     with open('/etc/resolv.conf', 'a') as resolv:
-        resolv.write('\n# Added by xmm7360\n')
+        resolv.write('\n# Added by xmm7560\n')
         for dns in dns_values['v4'] + dns_values['v6']:
             resolv.write('nameserver %s\n' % dns)
 

--- a/rpc/rpc.py
+++ b/rpc/rpc.py
@@ -29,7 +29,7 @@ class XMMRPC(object):
         desc = resp['type']
 
         if resp['type'] == 'unsolicited':
-            name = rpc_unsol_table.xmm7360_unsol.get(resp['code'], '0x%02x' % resp['code'])
+            name = rpc_unsol_table.xmm7560_unsol.get(resp['code'], '0x%02x' % resp['code'])
             desc = 'unsolicited: %s' % name
             self.handle_unsolicited(resp)
 
@@ -107,7 +107,7 @@ class XMMRPC(object):
         return {'tid': txid, 'type': t, 'code': code, 'body': body, 'content': content}
 
     def handle_unsolicited(self, message):
-        name = rpc_unsol_table.xmm7360_unsol.get(message['code'], None)
+        name = rpc_unsol_table.xmm7560_unsol.get(message['code'], None)
 
         if name == 'UtaMsNetIsAttachAllowedIndCb':
             self.attach_allowed = message['content'][2]
@@ -322,7 +322,7 @@ def UtaModeSet(rpc, mode):
     while True:
         msg = rpc.pump()
         # msg['txid'] will be mode_tid as well
-        if rpc_unsol_table.xmm7360_unsol.get(msg['code'], None) == 'UtaModeSetRspCb':
+        if rpc_unsol_table.xmm7560_unsol.get(msg['code'], None) == 'UtaModeSetRspCb':
             if msg['content'][0] != mode:
                 raise IOError("UtaModeSet was not able to set mode. FCC lock enabled?")
             return

--- a/rpc/rpc_unsol_table.py
+++ b/rpc/rpc_unsol_table.py
@@ -1,4 +1,4 @@
-xmm7360_unsol = {
+xmm7560_unsol = {
     0x003: "UtaMsSimApduCmdRspCb",
     0x005: "UtaMsSimApplicationRspCb",
     0x007: "UtaMsSimInfoIndCb",

--- a/rpc/xmm7360.h
+++ b/rpc/xmm7360.h
@@ -1,3 +1,0 @@
-#include <asm/ioctl.h>
-
-#define XMM7360_IOCTL_GET_PAGE_SIZE _IOC(_IOC_READ, 'x', 0xc0, sizeof(uint32_t))

--- a/rpc/xmm7560.h
+++ b/rpc/xmm7560.h
@@ -1,0 +1,3 @@
+#include <asm/ioctl.h>
+
+#define XMM7560_IOCTL_GET_PAGE_SIZE _IOC(_IOC_READ, 'x', 0xc0, sizeof(uint32_t))


### PR DESCRIPTION
The driver for 7360 did not work for my 7560 modem. Simply renaming all occurrences of `7360` to `7650` worked for me. I understand that this is not supposed to replace the 7360 driver, but wanted to raise awareness of this option. Maybe both drivers can be merged into one by someone more familiar with the codebase.