### PR TITLE
Fix build in kernel v5.15 and later

### DIFF
--- a/xmm7360.c
+++ b/xmm7360.c
@@ -1272,7 +1272,7 @@ static int xmm7360_tty_write(struct tty_struct *tty,
 	return written;
 }
 
-static int xmm7360_tty_write_room(struct tty_struct *tty)
+static unsigned int xmm7360_tty_write_room(struct tty_struct *tty)
 {
 	struct queue_pair *qp = tty->driver_data;
 	if (!xmm7360_qp_can_write(qp))

--- a/xmm7360.c
+++ b/xmm7360.c
@@ -40,6 +40,7 @@
 #include <linux/uaccess.h>
 #include <linux/wait.h>
 #include <linux/workqueue.h>
+#include <linux/version.h>
 #include <net/rtnetlink.h>
 
 MODULE_LICENSE("Dual BSD/GPL");
@@ -1555,7 +1556,11 @@ static void xmm7360_exit(void)
 	pci_unregister_driver(&xmm7360_driver);
 	unregister_chrdev_region(xmm_base, 8);
 	tty_unregister_driver(xmm7360_tty_driver);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	tty_driver_kref_put(xmm7360_tty_driver);
+#else
 	put_tty_driver(xmm7360_tty_driver);
+#endif
 }
 
 module_init(xmm7360_init);


### PR DESCRIPTION
In kernel 5.15 and later tty_driver_kref_put is to be used as put_tty_driver has been removed.
Fix, the write_room function signature to return unsigned int as expected by tty_operations