### PR TITLE
Added net_device_stats to push IO stats on the device

### DIFF
--- a/xmm7360.c
+++ b/xmm7360.c
@@ -212,6 +212,7 @@ struct xmm_dev {
 
 	struct xmm_net *net;
 	struct net_device *netdev;
+	struct net_device_stats stats;
 
 	int error;
 	int card_num;
@@ -919,8 +920,10 @@ static void xmm7360_net_flush(struct xmm_net *xn)
 {
 	struct sk_buff *skb;
 	struct mux_frame *frame = &xn->frame;
+	struct net_device_stats *stats = &xn->xmm->stats;
 	int ret;
 	u32 unknown = 0;
+	u32 pp = 0, bp = 0;
 
 	if (skb_queue_empty(&xn->queue))
 		return;
@@ -929,6 +932,8 @@ static void xmm7360_net_flush(struct xmm_net *xn)
 	xmm7360_mux_frame_add_tag(frame, 'ADBH', 0, NULL, 0);
 
 	while ((skb = skb_dequeue(&xn->queue))) {
+		pp++;
+		bp += skb->len;
 		ret = xmm7360_mux_frame_append_packet(frame, skb);
 		if (ret)
 			goto drop;
@@ -948,11 +953,15 @@ static void xmm7360_net_flush(struct xmm_net *xn)
 		goto drop;
 
 	xn->queued_packets = xn->queued_bytes = 0;
+	stats->tx_packets += pp;
+	stats->tx_bytes += bp;
 
 	return;
 
 drop:
 	dev_err(xn->xmm->dev, "Failed to ship coalesced frame");
+	stats->tx_dropped += pp;
+	return;
 }
 
 static enum hrtimer_restart xmm7360_net_deadline_cb(struct hrtimer *t)
@@ -1010,6 +1019,7 @@ static void xmm7360_net_mux_handle_frame(struct xmm_net *xn, u8 *data, int len)
 	struct sk_buff *skb;
 	void *p;
 	u8 ip_version;
+	struct net_device_stats *stats = &xn->xmm->stats;
 
 	first = (void *)data;
 	if (ntohl(first->tag) == 'ACBH')
@@ -1056,6 +1066,9 @@ static void xmm7360_net_mux_handle_frame(struct xmm_net *xn, u8 *data, int len)
 			return;
 		}
 
+		stats->rx_packets++;
+		stats->rx_bytes += skb->len;
+
 		netif_rx(skb);
 	}
 }
@@ -1084,10 +1097,17 @@ static void xmm7360_net_poll(struct xmm_dev *xmm)
 	}
 }
 
+static struct net_device_stats *xmm7360_net_stats(struct net_device *dev)
+{
+	struct xmm_net *xn = netdev_priv(dev);
+	return &xn->xmm->stats;
+}
+
 static const struct net_device_ops xmm7360_netdev_ops = {
 	.ndo_uninit = xmm7360_net_uninit,
 	.ndo_open = xmm7360_net_open,
 	.ndo_stop = xmm7360_net_close,
+	.ndo_get_stats = xmm7360_net_stats,
 	.ndo_start_xmit = xmm7360_net_xmit,
 };
 


### PR DESCRIPTION
The xmm7360 module works great. But it seems dead on the UI
because there are not stats available on the device. The system
monitor etc can see the device but can't show the current statistics
like speed, packets etc.

This patch fixes that and addds net_device_stats to the driver
and keeps track of the packets and number of bytes Tx/Rx'ed.

Signed-off-by: Himanshu Chauhan <hschauhan@nulltrace.org>