### PR TITLE
Add service safeguards

### DIFF
--- a/examples/xmm7360.service
+++ b/examples/xmm7360.service
@@ -6,10 +6,10 @@ Requires=multi-user.target systemd-user-sessions.service
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/sh -c 'until [ -e "/dev/xmm0" ]; do /usr/bin/sleep 1; done'
 ExecStart=/usr/rpc/open_xdatachannel.py -c /etc/xmm7360
 RemainAfterExit=yes
-TimeoutSec=60
-
+TimeoutSec=300
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
My experience with the example service provided is that, most of the time, it fails to start because the `/dev/xmm0` device wasn't created yet.
This modification ensures the device was created before attempting to start the RPC communication with it.
It still can fail after a (longer) timeout of 300 seconds.