### PR TITLE
fix build with kernels >= 5.18.0

### DIFF
--- a/xmm7360.c
+++ b/xmm7360.c
@@ -1452,12 +1452,11 @@ static int xmm7360_probe(struct pci_dev *dev, const struct pci_device_id *id)
 	}
 	pci_set_master(dev);
 
-	ret = pci_set_dma_mask(dev, 0xffffffffffffffff);
+	ret = dma_set_mask_and_coherent(xmm->dev, DMA_BIT_MASK(64));
 	if (ret) {
 		dev_err(xmm->dev, "Cannot set DMA mask\n");
 		goto fail;
 	}
-	dma_set_coherent_mask(xmm->dev, 0xffffffffffffffff);
 
 	ret = pci_request_region(dev, 0, "xmm0");
 	if (ret) {


### PR DESCRIPTION
The `pci-dma-compat.h` API has been removed since linux 7968778914e53788a01c2dee2692cab157de9ac0
The "new" api is available for about 9 years now.

Fixes #179 
Although one has to blacklist iosm (or do `rmmod iosm`) because it otherwise reserves the xmm7360 card since 5.18. (Thanks @regenman)