### PR TITLE
Added DKMS support and documentation

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -42,3 +42,105 @@ echo "nameserver 1.1.1.1" | sudo tee -a /etc/resolv.conf
 echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
 echo "nameserver 9.9.9.9" | sudo tee -a /etc/resolv.conf
 ```
+
+# Installing with DKMS
+Using DKMS (https://wiki.archlinux.org/title/Dynamic_Kernel_Module_Support) allows you to automate the **compilation** and **signing** of kernel modules, for example whenever you update your kernel.
+
+DKMS also has many other features, like the auto-generation of `.deb` for a particular kernel. See `man dkms` for more.
+
+## Compiling xmm7360.ko with DKMS
+The following steps replaces the commands from `Installing/Ubuntu 20.04`, up to and including `make && make load`. **Do not run `lte setup`.**
+
+First, install DKMS and other dependencies:
+```bash
+sudo apt install dkms
+sudo apt install build-essential python3-pyroute2 python3-configargparse git
+```
+
+Then, install the source code to `/usr/src/`:
+```bash
+TMP=$(mktemp -d)
+cd $TMP
+
+# Clone the Repository
+git clone https://github.com/xmm7360/xmm7360-pci.git 
+cd xmm7360-pci
+## For a particular branch/commit, run 'git checkout <REF>' here
+
+# Feed Commit ID as Package Version to dkms.conf
+COMMIT_ID=$(git rev-parse HEAD)
+sed "s/COMMIT_ID_VERSION/$COMMIT_ID/g" dkms.tmpl.conf > dkms.conf
+
+# Install in /usr/src
+sudo cp -r ./ /usr/src/xmm7360-pci-$COMMIT_ID/
+```
+
+Now, you can use DKMS to automatically build and sign the kernel module for the curent kernel with one simple command:
+```bash
+sudo dkms install xmm7360-pci/$COMMIT_ID
+```
+
+You can now manually load the kernel module with:
+```bash
+sudo modprobe xmm7360
+```
+
+To load the `xmm7360` module automatically on boot, create the following file:
+
+`/etc/modules-load.d/xmm7360.conf`
+```bash
+xmm7360
+```
+
+**Make sure to test your setup before auto-loading the module**.
+
+## Running w/DKMS Install
+**Do not run `lte setup`**. Instead, just run `sudo ./scripts/lte.sh up` after loading the kernel module.
+
+# Signing for Secure Boot
+If you use Secure Boot, you'll get `Operation not permitted` when executing `modprobe xmm7360` (ex. through `make load`). This is because Secure Boot requires all kernel code to be signed by a trusted party.
+
+DKMS can easily manage signing kernel modules for you. All you have to do, is generate the signing keypair, and enroll it into your BIOS.
+
+First, you need to get openssl and mokutil.
+```bash
+sudo apt install openssl mokutil
+```
+
+Next, generate the signing keys into `/root`:
+```bash
+openssl req -new -x509 -newkey rsa:2048 \
+-keyout /root/mok.priv \
+-outform DER -out /root/mok.der \
+-nodes -days 36500 \
+-subj "/CN=user Kmod Signing MOK"
+```
+
+Enroll the public key into the firmware:
+```
+sudo mokutil --import /root/mok.der
+```
+
+Now, restart your computer. Your BIOS should prompt you to accept the key, before booting into the system.
+
+**If you use DKMS** you only need to configure DKMS to use the pre-shipped signing tool to sign kernel modules whenever it builds them:
+
+`/etc/dkms/framework.conf`
+```bash
+...
+## Script to sign modules during build, script is called with kernel version
+## and module name
+sign_tool="/etc/dkms/sign_helper.sh"
+```
+
+If it for some reason doesn't exist, create it:
+
+`/etc/dkms/sign_helper.sh`
+```bash
+#!/bin/sh
+/lib/modules/"$1"/build/scripts/sign-file sha512 /root/mok.priv /root/mok.der "$2"
+```
+
+**If you don't use DKMS** you can try (untested) running the above script using:
+- `$1 => linux-image-<version>`
+- `$2 => /path/to/xmm7360.ko`

--- a/dkms.tmpl.conf
+++ b/dkms.tmpl.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME="xmm7360-pci"
+PACKAGE_VERSION="COMMIT_ID_VERSION"
+
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+BUILT_MODULE_NAME[0]="xmm7360"
+DEST_MODULE_LOCATION[0]="/extra"
+AUTOINSTALL="yes"


### PR DESCRIPTION
I'm using DKMS to manage this module, in part because it makes it easy to manage signing the kernel module to appease Secure Boot. It makes my life a lot simpler, so I thought I'd contribute it back. Hope it can be useful!

This PR adds:
- General docs for signing this module for use with Secure Boot systems in `INSTALLING.md`, both with and without DKMS.
- Documentation on using DKMS to install and sign this module.
- A `dkms.tmpl.conf` file, which requires the user to replace `COMMIT_ID_VERSION` (with a `sed` script provided in `INSTALLING.md`) and write the result to `dkms.conf`.

When the source repo is copied to `/usr/src`, the user-created `dkms.conf` is automatically picked up on by DKMS when performing `dkms install`. From there, everything works smoothly.

# Why no dkms.conf?
DKMS versioning is important - otherwise DKMS will never think there's been an update, even if there has been.

The only way I could think of to version `xmm7360-pci` was by commit-id, as there are no releases. Unfortunately, `dkms.conf` can't automatically grab the commit-id of `HEAD`.

We can't update `dkms.conf` every time there's a commit. So, we have to insist that the user runs a one-liner `sed` script (documented in `INSTALLING.md`), one avoids introducing the chore of manually updating a version string every time there's a change.

There's probably a better way, but this is simple and it works. Also, if someone happens to copy `dkms.tmpl.conf` directly into `dkms.conf`, it'll still work - the version will just be `COMMIT_ID_VERSION`.

# How-To (also in INSTALLING.md)
The following instructions are copy/pasted from `INSTALLING.md`. I've tested them on my own machine.
```bash
# Feed Commit ID as Package Version to dkms.conf
COMMIT_ID=$(git rev-parse HEAD)
sed "s/COMMIT_ID_VERSION/$COMMIT_ID/g" dkms.tmpl.conf > dkms.conf

# Install in /usr/src
sudo cp -r ./ /usr/src/xmm7360-pci-$COMMIT_ID/

# Install with DKMS
sudo dkms install xmm7360-pci/$COMMIT_ID
sudo modprobe xmm7360
```

After this, the user simply runs `sudo ./scripts/lte.sh up` as usual.