### PR TITLE
Unload iosm module before loading xmm7360

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
 
 load:
+	-sudo /sbin/rmmod iosm
 	-sudo /sbin/rmmod xmm7360
 	sudo /sbin/insmod xmm7360.ko
 


### PR DESCRIPTION
The built-in iosm module now supports the 7360 chip (in theory) and will automatically bind to it. This prevents xmm7360 from binding to the device.

Fixes #194 