### PR TITLE
Add support for vanilla Linux kernel 6.2

### DIFF
--- a/rpc/open_xdatachannel.py
+++ b/rpc/open_xdatachannel.py
@@ -39,7 +39,13 @@ parser.add_argument('-d', '--dbus', action="store_true",
 
 cfg, unknown = parser.parse_known_args()
 
-r = rpc.XMMRPC()
+r = None
+try:
+    r = rpc.XMMRPC()
+except Exception as ex:
+    logging.error(ex)
+    exit()
+
 ipr = IPRoute()
 
 r.execute('UtaMsSmsInit')

--- a/rpc/rpc.py
+++ b/rpc/rpc.py
@@ -15,7 +15,7 @@ def asn_int4(val):
 
 
 class XMMRPC(object):
-    def __init__(self, interfaces=['/dev/wwan0xmmrpc0', '/dev/xmm0/rpc']):
+    def __init__(self, interfaces=['/dev/xmm0/rpc', '/dev/wwan0xmmrpc0']):
         selected_interface = None
         for interface in interfaces:
             if os.path.exists(interface):

--- a/rpc/rpc.py
+++ b/rpc/rpc.py
@@ -15,8 +15,16 @@ def asn_int4(val):
 
 
 class XMMRPC(object):
-    def __init__(self, path='/dev/xmm0/rpc'):
-        self.fp = os.open(path, os.O_RDWR | os.O_SYNC)
+    def __init__(self, interfaces=['/dev/wwan0xmmrpc0', '/dev/xmm0/rpc']):
+        selected_interface = None
+        for interface in interfaces:
+            if os.path.exists(interface):
+                selected_interface = interface
+                break
+        if selected_interface is None:
+            raise IOError('XMM RPC interface does not exists')
+
+        self.fp = os.open(selected_interface, os.O_RDWR | os.O_SYNC)
 
         # loop over 1..255, excluding 0
         self.tid_gen = itertools.cycle(range(1, 256))


### PR DESCRIPTION
As of Linux Kernel 6.2, it now has an xmm7360-pci compatible interface
https://github.com/torvalds/linux/commit/d08b0f8f46e45a274fc8c9a5bc92cb9da70d9887

This PR adds enumeration of possible paths of XMM RPC interfaces.