### PR TITLE
fix compiler warning with kernel version 6.6

### DIFF
--- a/xmm7360.c
+++ b/xmm7360.c
@@ -1279,8 +1279,8 @@ static void xmm7360_tty_close(struct tty_struct *tty, struct file *filp)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-static long int xmm7360_tty_write(struct tty_struct *tty,
-			     const unsigned char *buffer, long unsigned int count)
+static ssize_t xmm7360_tty_write(struct tty_struct *tty,
+			     const unsigned char *buffer, size_t count)
 #else
 static int xmm7360_tty_write(struct tty_struct *tty,
 			     const unsigned char *buffer, int count)

--- a/xmm7360.c
+++ b/xmm7360.c
@@ -1278,8 +1278,13 @@ static void xmm7360_tty_close(struct tty_struct *tty, struct file *filp)
 		tty_port_close(&qp->port, tty, filp);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static long int xmm7360_tty_write(struct tty_struct *tty,
+			     const unsigned char *buffer, long unsigned int count)
+#else
 static int xmm7360_tty_write(struct tty_struct *tty,
 			     const unsigned char *buffer, int count)
+#endif
 {
 	struct queue_pair *qp = tty->driver_data;
 	int written;


### PR DESCRIPTION
I came across this warning after upgrading from kernel 6.5 to 6.6.
The issue seems pretty similar to #139.

```
/home/marc/src/xmm7360-pci/xmm7360.c:1342:18: error: initialization of ‘ssize_t (*)(struct tty_struct *, const u8 *, size_t)’ {aka ‘long int (*)(struct tty_struct *, const unsigned char *, long unsigned int)’} from incompatible pointer type ‘int (*)(struct tty_struct *, const unsigned char *, int)’ [-Werror=incompatible-pointer-types]
 1342 |         .write = xmm7360_tty_write,
      |                  ^~~~~~~~~~~~~~~~~
/home/marc/src/xmm7360-pci/xmm7360.c:1342:18: note: (near initialization for ‘xmm7360_tty_ops.write’)
```

This patch fixes what the compiler complains about, and lets xmm7360 build again.
