### PR TITLE
conditions based on kernel version

### DIFF
--- a/rpc/open_xdatachannel.py
+++ b/rpc/open_xdatachannel.py
@@ -15,7 +15,6 @@ import logging
 # must do this before importing pyroute2
 logging.basicConfig(level=logging.DEBUG)
 
-
 parser = configargparse.ArgumentParser(
     description='Hacky tool to bring up XMM7x60 modem',
     default_config_files=[
@@ -237,4 +236,6 @@ for d in devices:
             prop_iface.Set("org.freedesktop.NetworkManager.Device",
                            "Managed", dbus.Boolean(1))
 
-manager.ActivateConnection(connection_path, devpath, "/")
+            print(devpath)
+            manager.ActivateConnection(connection_path, devpath, "/")
+            break

--- a/rpc/open_xdatachannel.py
+++ b/rpc/open_xdatachannel.py
@@ -236,6 +236,5 @@ for d in devices:
             prop_iface.Set("org.freedesktop.NetworkManager.Device",
                            "Managed", dbus.Boolean(1))
 
-            print(devpath)
             manager.ActivateConnection(connection_path, devpath, "/")
             break

--- a/xmm7360.c
+++ b/xmm7360.c
@@ -1279,8 +1279,8 @@ static void xmm7360_tty_close(struct tty_struct *tty, struct file *filp)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-static long int xmm7360_tty_write(struct tty_struct *tty,
-			     const unsigned char *buffer, long unsigned int count)
+static ssize_t xmm7360_tty_write(struct tty_struct *tty,
+			     const unsigned char *buffer, size_t count)
 #else
 static int xmm7360_tty_write(struct tty_struct *tty,
 			     const unsigned char *buffer, int count)

--- a/xmm7360.c
+++ b/xmm7360.c
@@ -1278,8 +1278,13 @@ static void xmm7360_tty_close(struct tty_struct *tty, struct file *filp)
 		tty_port_close(&qp->port, tty, filp);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static long int xmm7360_tty_write(struct tty_struct *tty,
+			     const unsigned char *buffer, long unsigned int count)
+#else
 static int xmm7360_tty_write(struct tty_struct *tty,
 			     const unsigned char *buffer, int count)
+#endif
 {
 	struct queue_pair *qp = tty->driver_data;
 	int written;


### PR DESCRIPTION
- Use of hrtimer_setup for kernel >= 6.11 and hrtimer_init() for kernel < 6.11
- Use of ssize_t / size_t for kernel >= 6.6.0
- Bug fixes.